### PR TITLE
Add MkDocs docs and GitHub Pages workflow

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -1,0 +1,21 @@
+name: Deploy MkDocs
+
+on:
+  push:
+    branches: [ main ]
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install mkdocs
+      - name: Deploy
+        run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore MkDocs build directory
+site/
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This repository is a minimal demonstration of Codex's ability to update projects. It includes a Python script that greets users.
 
+Documentation for the project is generated with [MkDocs](https://www.mkdocs.org/) and published via GitHub Pages.
+
 ## Usage
 
 Run `hello.py` with an optional name argument:

--- a/docs/about.md
+++ b/docs/about.md
@@ -1,0 +1,8 @@
+# About
+
+HelloCodex is a minimal project used to test Codex's ability to update code repositories.
+
+The codebase includes:
+
+- `hello.py` - prints a greeting for a name you provide.
+- `text_rpg.py` - a tiny text RPG battle demonstrating basic Python classes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,8 @@
+# Welcome to HelloCodex
+
+This site contains documentation for the sample Python scripts in this repository.
+
+- [`hello.py`](../hello.py) demonstrates a simple greeting function.
+- [`text_rpg.py`](../text_rpg.py) is a minimal text-based RPG battle.
+
+Check the [README](../README.md) for usage instructions.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,6 @@
+site_name: HelloCodex Docs
+nav:
+  - Home: index.md
+  - About: about.md
+
+# GitHub pages deployment config will be handled by GitHub Actions


### PR DESCRIPTION
## Summary
- document project with MkDocs
- deploy documentation on every push using GitHub Actions
- ignore build artifacts

## Testing
- `mkdocs build`
- `mkdocs --version`


------
https://chatgpt.com/codex/tasks/task_e_683fdc941998832bae918c8ad7c396a7